### PR TITLE
feature(backend/src/routes/utils/utils.js): building customFindOrCreate()

### DIFF
--- a/backend/src/routes/utils/utils.js
+++ b/backend/src/routes/utils/utils.js
@@ -1,0 +1,11 @@
+const customFindOrCreate = (data, model, where, defaults) => {
+  const result = [];
+  for (let i = 0; i < data.length; i++) {
+    const [instance, created] = await model.findOrCreate({
+      where,
+      defaults,
+    });
+    result.push(instance);    
+  }
+  return result;
+};


### PR DESCRIPTION
Estoy armando la función customFindOrCreate() para reutilizarla cuando creas una tupla e.g un nuevo producto y queres crear tuplas en la tabla intermedia (relacion entre Entidades) pero si alguna de las entradas de la segunda Entidad ya existe no la creas sino que usas la que ya existe.